### PR TITLE
Skipped loading profile pictures in mupro list

### DIFF
--- a/src/@arpa/components/avatar/avatar.component.ts
+++ b/src/@arpa/components/avatar/avatar.component.ts
@@ -28,6 +28,9 @@ export class AvatarComponent implements OnInit, OnDestroy {
   @Input()
   imageSize = 100;
 
+  @Input()
+  skipLoadingPicture = false;
+
   imageUrl: string;
 
   constructor(private authService: AuthService, private personService: PersonService) {}
@@ -51,7 +54,7 @@ export class AvatarComponent implements OnInit, OnDestroy {
   loadAvatar() {
     this.imageUrl = 'assets/common/images/avatar.png';
     const potentialId = this.getPotentialPersonId();
-    if (potentialId) {
+    if (potentialId && !this.skipLoadingPicture) {
       this.personService.getProfilePicture(potentialId, this.imageSize).subscribe(
         (data) => {
           const reader = new FileReader();

--- a/src/app/features/mupro/mupro.component.html
+++ b/src/app/features/mupro/mupro.component.html
@@ -1,29 +1,28 @@
 <arpa-split-view>
   <ng-template #sideViewTemplate>
-    <arpa-graph-ql-feed #feedSource [contentTemplate]='feed' [query]='query' [variables]='{take:50}'>
+    <arpa-graph-ql-feed #feedSource [contentTemplate]="feed" [query]="query" [variables]="{ take: 50 }">
       <ng-template #feed let-feed>
-        <div [class.hasSelection]='person'>
+        <div [class.hasSelection]="person">
           <arpa-table
-            (lazyEvents)='feedSource.onLazy($event)'
-            (rowClickEvents)='select($event)'
-            [columnFilter]='false'
-            [feed]='feed'
-            [rowTemplateRef]='rowTemplate'
-            [showFilter]='true'
-            [showFirstLastIcon]='false'
-            [showPageLinks]='false'
-            [showPagination]='true'
-            selectionMode='single'
-            tableStyleClass='arpa-table-list'
+            (lazyEvents)="feedSource.onLazy($event)"
+            (rowClickEvents)="select($event)"
+            [columnFilter]="false"
+            [feed]="feed"
+            [rowTemplateRef]="rowTemplate"
+            [showFilter]="true"
+            [showFirstLastIcon]="false"
+            [showPageLinks]="false"
+            [showPagination]="true"
+            selectionMode="single"
+            tableStyleClass="arpa-table-list"
           ></arpa-table>
           <ng-template #rowTemplate let-row>
             <td>
-              <arpa-avatar [image]='false' [user]='row.person' size='large'></arpa-avatar>
-              <div class='details'>
-                <div class='name'>{{row.person.givenName}} {{row.person.surname}}</div>
-                <div class='profile'>{{row.instrument.name}}</div>
-                <div class='created' pTooltip="{{'MUPRO_CREATION_DATE' | translate}}">
-                  created {{row.createdAt |date: 'yyyy-MM'}}</div>
+              <arpa-avatar [image]="false" [user]="row.person" size="large" [skipLoadingPicture]="true"></arpa-avatar>
+              <div class="details">
+                <div class="name">{{ row.person.givenName }} {{ row.person.surname }}</div>
+                <div class="profile">{{ row.instrument.name }}</div>
+                <div class="created" pTooltip="{{ 'MUPRO_CREATION_DATE' | translate }}">created {{ row.createdAt | date : 'yyyy-MM' }}</div>
               </div>
             </td>
           </ng-template>
@@ -32,8 +31,8 @@
     </arpa-graph-ql-feed>
   </ng-template>
   <ng-template #contentDefaultTemplate>
-    <div class='default p-d-flex'>
-      <i class='pi pi-user'></i>
+    <div class="default p-d-flex">
+      <i class="pi pi-user"></i>
     </div>
   </ng-template>
 </arpa-split-view>


### PR DESCRIPTION
This PR temporarily disables loading profile pictures in the MuPro list page in order to reduce the number of requests made to the backend.

The component is being created 2 times per entry and each profile picture query is made per entry regardless of the picture existing or not.

If we have 3 Musician Profiles for Wolf, the system will make 3 requests to retrieve the profile picture (one per musician profile) * 2, one per rendering of the component. This makes Arpa making 6 requests to retrieve the picture of this single person, which should not happen.