### PR TITLE
Update property paths in various components

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -71,7 +71,7 @@ export class AppComponent implements OnInit, OnDestroy {
         // Remove sensible data on logout.
         this.meService.cleanStorage();
       } else if (event === AuthEvents.LOGIN) {
-        // Make sure an applicable user-layout has a ready to use QRCode.
+        // Make sure an applicable user has a ready to use QRCode.
         // This observable is completed by default. No need to unsubscribe.
         this.meService.getMyQrCode().subscribe();
       }

--- a/src/app/features/performer/performer-list/performer-list.component.ts
+++ b/src/app/features/performer/performer-list/performer-list.component.ts
@@ -48,7 +48,7 @@ export class PerformerListComponent {
     { label: 'CREATED_BY', property: 'createdBy', type: 'text', show: false },
     { label: 'MODIFIED_AT', property: 'createdAt', type: 'date', show: false },
     { label: 'MODIFIED_BY', property: 'modifiedBy', type: 'text', show: false },
-    { label: 'USER_CREATED_AT', property: 'person.user-layout.createdAt', type: 'date', show: false },
+    { label: 'USER_CREATED_AT', property: 'person.user.createdAt', type: 'date', show: false },
   ];
   @ViewChild('feedSource') private feedSource: GraphQlFeedComponent;
 

--- a/src/app/features/projects/project-layout/accepted-participants/accepted-participants.component.ts
+++ b/src/app/features/projects/project-layout/accepted-participants/accepted-participants.component.ts
@@ -29,7 +29,7 @@ export class AcceptedParticipantsComponent implements OnInit, OnDestroy {
   columns: ColumnDefinition<any>[] = [
     { label: 'projects.PARTICIPANTS', property: 'musicianProfile.person.displayName', type: 'text' },
     { label: 'projects.INSTRUMENT', property: 'musicianProfile.instrument.name', type: 'text' },
-    { label: 'projects.EMAIL', property: 'musicianProfile.person.user-layout.normalizedEmail', type: 'text' },
+    { label: 'projects.EMAIL', property: 'musicianProfile.person.user.normalizedEmail', type: 'text' },
     {
       label: 'mupro.QUALIFICATION',
       property: 'musicianProfile.qualification.selectValue.name',

--- a/src/app/features/projects/project-layout/project-participants/project-participants.component.ts
+++ b/src/app/features/projects/project-layout/project-participants/project-participants.component.ts
@@ -27,7 +27,7 @@ export class ProjectParticipantsComponent implements OnInit, OnDestroy {
   columns: ColumnDefinition<ProjectParticipationDto>[] = [
     { label: 'projects.PARTICIPANTS', property: 'musicianProfile.person.displayName', type: 'text' },
     { label: 'projects.INSTRUMENT', property: 'musicianProfile.instrument.name', type: 'text' },
-    { label: 'projects.EMAIL', property: 'musicianProfile.person.user-layout.normalizedEmail', type: 'text' },
+    { label: 'projects.EMAIL', property: 'musicianProfile.person.user.normalizedEmail', type: 'text' },
     {
       label: 'projects.PARTICIPATION_STATUS_INVITATION',
       property: 'invitationStatus',

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -20,9 +20,9 @@
 
 /**
  * By default, zone.js will patch all possible macroTask and DomEvents
- * user-layout can disable parts of macroTask/DomEvents patch by setting following flags
+ * user can disable parts of macroTask/DomEvents patch by setting following flags
  * because those flags need to be set before `zone.js` being loaded, and webpack
- * will put import in the top of bundle, so user-layout need to create a separate file
+ * will put import in the top of bundle, so user need to create a separate file
  * in this directory (for example: zone-flags.ts), and put the following flags
  * into that file, and then add the following code before importing zone.js.
  * import './zone-flags';


### PR DESCRIPTION
Changes have been made to correct the property paths in several components, specifically regarding `user-layout` which has been renamed to `user`. This has affected components such as accepted-participants.component, project-participants.component, performer-list.component, app.component, and polyfills.ts. The changes ensure the correct property paths are referenced, which should improve the accuracy and efficiency of data extraction.