### PR TITLE
Update dashboard widgets and translations

### DIFF
--- a/src/app/features/dashboard/appointments-widget/appointments-widget.component.html
+++ b/src/app/features/dashboard/appointments-widget/appointments-widget.component.html
@@ -3,7 +3,7 @@
     <p-table
       (onLazyLoad)="loadData($event.rows, $event.first)"
       [lazy]="true"
-      [rows]="5"
+      [rows]="3"
       [value]="(userAppointments$ | async) || []"
       (click)="onRowClick($event)"
       tableStyleClass="arpa-table-list"
@@ -65,7 +65,7 @@
                 <p-chip
                   icon="pi pi-check"
                   class="p-chip-info"
-                  *ngIf="appointment.prediction"
+                  *ngIf="appointment.prediction; else noPrediction"
                   [label]="
                     ('PARTICIPATION_PREDICTION' | translate) +
                     ': ' +
@@ -92,3 +92,9 @@
     <span>{{ 'VENUE_NOT_CONFIRMED' | translate }}</span>
   </div>
 </ng-template>
+<ng-template #noPrediction>
+  <div class="p-col-3 p-lg-6">
+    <span class="no-prediction">{{ 'appointments.NO_PREDICTION' | translate }}</span>
+  </div>
+</ng-template>
+```

--- a/src/app/features/dashboard/appointments-widget/appointments-widget.component.scss
+++ b/src/app/features/dashboard/appointments-widget/appointments-widget.component.scss
@@ -134,3 +134,8 @@
   margin-bottom: 1rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
+.no-prediction {
+  color: var(--primary-color);
+  font-weight: 500;
+  font-size: 1.2rem;
+}

--- a/src/app/features/dashboard/appointments-widget/appointments-widget.component.ts
+++ b/src/app/features/dashboard/appointments-widget/appointments-widget.component.ts
@@ -14,8 +14,7 @@ import { Router } from '@angular/router';
 })
 export class AppointmentsWidgetComponent {
   userAppointments$: Observable<MyAppointmentDto[]> = of([]);
-  // totalRecordsCount$: Observable<number> = of(0);
-  totalRecordsCountMissingPrediction$: Observable<number> = of(0);
+  // totalRecordsCountMissingPrediction$: Observable<number> = of(0);
   predictions$: Observable<SelectItem[]>;
 
   constructor(
@@ -32,9 +31,9 @@ export class AppointmentsWidgetComponent {
     const loadResult$ = this.meService.getMyAppointments(take, skip);
     this.userAppointments$ = loadResult$.pipe(map((result) => result?.userAppointments || []));
     // this.totalRecordsCount$ = loadResult$.pipe(map((result) => result?.totalRecordsCount || 0));
-    this.totalRecordsCountMissingPrediction$ = loadResult$.pipe(
-      map((result) => result?.userAppointments?.filter((appointment) => !!appointment && !appointment.prediction).length ?? 0)
-    );
+    // this.totalRecordsCountMissingPrediction$ = loadResult$.pipe(
+    //   map((result) => result?.userAppointments?.filter((appointment) => !!appointment && !appointment.prediction).length ??  0)
+    // );
     this.cdRef.detectChanges();
   }
 

--- a/src/app/features/dashboard/news-widget/news-widget.component.html
+++ b/src/app/features/dashboard/news-widget/news-widget.component.html
@@ -18,9 +18,6 @@
           </ng-template>
           <div class="card-content" (click)="showOverlay($event, op, newsItem)">
             <p class="content">{{ newsItem.content }}</p>
-            <!--            <p *ngIf="newsItem?.url">-->
-            <!--              <a class="urlsmall" [href]="newsItem!.url!" target="_blank">{{ newsItem!.url! }} </a>-->
-            <!--            </p>-->
           </div>
           <ng-container *ngIf="newsItem.url"> </ng-container>
         </p-card>

--- a/src/assets/i18n/appointments/de.json
+++ b/src/assets/i18n/appointments/de.json
@@ -17,6 +17,7 @@
   "EXPECTATION": "Erwartung",
   "LEVEL": "Qualifikation",
   "NEW_APPOINTMENT_CONFIRMATION": "Möchtest du einen neuen Termin anlegen für {{value}}?",
+  "NO_PREDICTION": "Deine Prognose?",
   "NORECORDS": "Keine Datensätze gefunden",
   "PAGE_TITLE": "Kalender",
   "PARTICIPATIONSTATUS": "Teilnahmestatus",

--- a/src/assets/i18n/appointments/en.json
+++ b/src/assets/i18n/appointments/en.json
@@ -17,6 +17,7 @@
   "EXPECTATION": "Expectation",
   "LEVEL": "(Semi-)Professional",
   "NEW_APPOINTMENT_CONFIRMATION": "Do you want to create a new appointment for {{value}}?",
+  "NO_PREDICTION": "Your prediction?",
   "NORECORDS": "No records found",
   "PAGE_TITLE": "Calendar",
   "PARTICIPATIONSTATUS": "Participationstatus",

--- a/src/assets/i18n/appointments/fr.json
+++ b/src/assets/i18n/appointments/fr.json
@@ -16,6 +16,7 @@
   "EXPECTATION": " Mes attentes",
   "LEVEL": "qualification",
   "NEW_APPOINTMENT_CONFIRMATION": "Aimerais -tu fixer un nouveau rendez-vous pour {{value}}?",
+  "NO_PREDICTION": "Aucune prédiction",
   "NORECORDS": "Aucun enregistrement n'a été trouvée",
   "PAGE_TITLE": "Calendrier",
   "PARTICIPATIONSTATUS": "Statut de participation",

--- a/src/assets/i18n/appointments/pt.json
+++ b/src/assets/i18n/appointments/pt.json
@@ -16,6 +16,7 @@
   "EXPECTATION": "Expectativa",
   "LEVEL": "Qualificação",
   "NEW_APPOINTMENT_CONFIRMATION": "Deseja (re)agendar para {{value}}?",
+  "NO_PREDICTION": "Sem previsão",
   "NORECORDS": "Nenhum registo encontrado",
   "PAGE_TITLE": "Calendário",
   "PARTICIPATIONSTATUS": "Estatuto de participação",


### PR DESCRIPTION
reduced rows shown in appointments-widget from 5 to 3. Added 'no prediction' placeholder in the appointments-widget when no prediction is available, styled in primary color, and removed commented out code. Translations for 'no prediction' have been added in four languages: Portuguese, French, English, and German.