### PR TITLE
fixed chart loading on selection and prediction changed. 

### DIFF
--- a/src/app/features/appointments/edit-appointment/edit-appointment.component.html
+++ b/src/app/features/appointments/edit-appointment/edit-appointment.component.html
@@ -34,7 +34,9 @@
             [legend]="true"
             *ngIf="predictionsChartValues?.length"
           ></arpa-chart>
-          <strong *ngIf="!predictionsChartValues?.length">{{ 'appointments.NO_PREDICTIONS_AVAILABLE' | translate }}</strong>
+          <p class="no-predictions-yet" *ngIf="!predictionsChartValues?.length">
+            {{ 'appointments.NO_PREDICTIONS_AVAILABLE' | translate }}
+          </p>
         </div>
       </div>
       <div class="right-column" *ngIf="!isNew">

--- a/src/app/features/appointments/edit-appointment/edit-appointment.component.scss
+++ b/src/app/features/appointments/edit-appointment/edit-appointment.component.scss
@@ -59,6 +59,12 @@ th {
   align-items: center;
   height: 100%;
 }
+.no-predictions-yet {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
 
 /* Media query for screens smaller than 768px (like most mobile devices) */
 @media screen and (max-width: 768px) {

--- a/src/app/features/appointments/edit-appointment/edit-appointment.component.ts
+++ b/src/app/features/appointments/edit-appointment/edit-appointment.component.ts
@@ -238,6 +238,11 @@ export class EditAppointmentComponent implements OnInit {
   }
 
   public prepareDonutChartData() {
+    this.predictionChartKeys = [];
+    this.predictionsChartValues = [];
+    this.acceptedSectionName = [];
+    this.accpetedSectionCount = [];
+
     const predictionCounts: { [key: string]: number } = {};
     const sectionCounts: { [key: string]: number } = {};
 
@@ -528,6 +533,7 @@ export class EditAppointmentComponent implements OnInit {
       .subscribe((_) => {
         this.notificationsService.success('appointments.PREDICTION_SET');
       });
+    this.prepareDonutChartData();
   }
 
   onAllDayChanged(isAllDay: boolean) {

--- a/src/assets/i18n/appointments/de.json
+++ b/src/assets/i18n/appointments/de.json
@@ -21,6 +21,7 @@
   "LEVEL": "Qualifikation",
   "NEW_APPOINTMENT_CONFIRMATION": "Möchtest du einen neuen Termin anlegen für {{value}}?",
   "NO_ACCEPTANCES_YET": "Noch keine Zusagen vorhanden",
+  "NO_PREDICTIONS_AVAILABLE": "Keine Vorhersagen verfügbar",
   "NO_PREDICTION": "Deine Prognose?",
   "NORECORDS": "Keine Datensätze gefunden",
   "NOTIFICATION_SENT": "Die E-Mail-Benachrichtigungen wurde gesendet",

--- a/src/assets/i18n/appointments/en.json
+++ b/src/assets/i18n/appointments/en.json
@@ -21,6 +21,7 @@
   "LEVEL": "(Semi-)Professional",
   "NEW_APPOINTMENT_CONFIRMATION": "Do you want to create a new appointment for {{value}}?",
   "NO_ACCEPTANCES_YET": "No acceptances yet",
+  "NO_PREDICTIONS_AVAILABLE": "No predictions available",
   "NO_PREDICTION": "Your prediction?",
   "NORECORDS": "No records found",
   "NOTIFICATION_SENT": "The e-mail notifications have been sent",

--- a/src/assets/i18n/appointments/fr.json
+++ b/src/assets/i18n/appointments/fr.json
@@ -20,6 +20,7 @@
   "LEVEL": "qualification",
   "NEW_APPOINTMENT_CONFIRMATION": "Aimerais -tu fixer un nouveau rendez-vous pour {{value}}?",
   "NO_ACCEPTANCES_YET": "Aucune acceptation pour le moment",
+  "NO_PREDICTIONS_AVAILABLE": "Aucune prédiction disponible",
   "NO_PREDICTION": "Aucune prédiction",
   "NORECORDS": "Aucun enregistrement n'a été trouvée",
   "NOTIFICATION_SENT": "Les notifications par e-mail ont été envoyées",

--- a/src/assets/i18n/appointments/pt.json
+++ b/src/assets/i18n/appointments/pt.json
@@ -21,6 +21,7 @@
   "NEW_APPOINTMENT_CONFIRMATION": "Deseja (re)agendar para {{value}}?",
   "NO_ACCEPTANCES_YET": "Ainda sem aceitações",
   "NO_PREDICTION": "Sem previsão",
+  "NO_PREDICTIONS_AVAILABLE": "Sem previsões disponíveis",
   "NORECORDS": "Nenhum registo encontrado",
   "NOTIFICATION_SENT": "As notificações por correio eletrónico foram enviadas",
   "PAGE_TITLE": "Calendário",

--- a/src/assets/i18n/appointments/ru.json
+++ b/src/assets/i18n/appointments/ru.json
@@ -21,6 +21,7 @@
   "LEVEL": "Квалификация",
   "NEW_APPOINTMENT_CONFIRMATION": "Вы хотите создать новую встречу для {{value}}?",
   "NO_ACCEPTANCES_YET": "Пока нет подтверждений",
+  "NO_PREDICTIONS_AVAILABLE": "Прогнозы недоступны",
   "NO_PREDICTION": "Ваш прогноз?",
   "NORECORDS": "Записи данных не найдены",
   "NOTIFICATION_SENT": "Уведомления по электронной почте отправлены",

--- a/src/assets/i18n/appointments/ua.json
+++ b/src/assets/i18n/appointments/ua.json
@@ -21,6 +21,7 @@
   "LEVEL": "Кваліфікація",
   "NEW_APPOINTMENT_CONFIRMATION": "Ви хочете створити нову зустріч для {{value}}?",
   "NO_ACCEPTANCES_YET": "Ще немає підтверджень",
+  "NO_PREDICTIONS_AVAILABLE": "Прогнози недоступні",
   "NO_PREDICTION": "Ваш прогноз?",
   "NORECORDS": "Не знайдено жодного запису даних",
   "NOTIFICATION_SENT": "Сповіщення на електронну пошту надіслано",


### PR DESCRIPTION
now the charts a drawn with correct numbers and without doubling keys. both charts are redrawn every time a section or prediction is changed. 
+ added forgotten translation